### PR TITLE
use .emitter

### DIFF
--- a/can-kefir-test.js
+++ b/can-kefir-test.js
@@ -106,13 +106,13 @@ QUnit.test("Kefir.emitterProperty", function(){
 	}
 	canReflect.onKeyValue(stream,"value", valueHandler);
 
-	stream.emit(1);
+	stream.emitter.emit(1);
 
 	QUnit.equal( canReflect.getKeyValue(stream,"value"), 1, "got initial value");
 
 	canReflect.setKeyValue( stream, "value", 2);
 	canReflect.offKeyValue(stream,"value", valueHandler);
-	stream.emit(3);
+	stream.emitter.value(3);
 
 
 	var errorEventCount = 0;
@@ -126,12 +126,12 @@ QUnit.test("Kefir.emitterProperty", function(){
 	}
 	canReflect.onKeyValue(stream,"error", errorHandler);
 
-	stream.error("a");
+	stream.emitter.error("a");
 
 	QUnit.equal( canReflect.getKeyValue(stream,"error"), "a", "got initial value");
 
 	canReflect.offKeyValue(stream,"error", errorHandler);
-	stream.error("b");
+	stream.emitter.error("b");
 });
 
 QUnit.test("get behavior with constant stream", function(){

--- a/can-kefir-test.js
+++ b/can-kefir-test.js
@@ -106,13 +106,13 @@ QUnit.test("Kefir.emitterProperty", function(){
 	}
 	canReflect.onKeyValue(stream,"value", valueHandler);
 
-	stream.value(1);
+	stream.emit(1);
 
 	QUnit.equal( canReflect.getKeyValue(stream,"value"), 1, "got initial value");
 
 	canReflect.setKeyValue( stream, "value", 2);
 	canReflect.offKeyValue(stream,"value", valueHandler);
-	stream.value(3);
+	stream.emit(3);
 
 
 	var errorEventCount = 0;

--- a/can-kefir.js
+++ b/can-kefir.js
@@ -163,26 +163,28 @@ if (Kefir) {
 		var property = stream.toProperty(function(){
 			return lastValue;
 		});
-		property.emit = function(newValue) {
-			if(emitter) {
-				return emitter.emit(newValue);
-			} else {
-				setLastValue = true;
-				lastValue = newValue;
+		property.emitter = {
+			value: function(newValue) {
+				if(emitter) {
+					return emitter.emit(newValue);
+				} else {
+					setLastValue = true;
+					lastValue = newValue;
+				}
+			},
+			error: function(error) {
+				if(emitter) {
+					return emitter.error(error);
+				} else {
+					lastError = error;
+				}
 			}
 		};
-
-		property.error = function(error) {
-			if(emitter) {
-				return emitter.error(error);
-			} else {
-				lastError = error;
-			}
-		};
+		property.emitter.emit = property.emitter.value;
 
 		canReflect.assignSymbols(property,{
 			"can.setKeyValue": function(key, value){
-				this[key === "value" ? "emit" : key](value);
+				this.emitter[key](value);
 			}
 		});
 

--- a/can-kefir.js
+++ b/can-kefir.js
@@ -163,9 +163,9 @@ if (Kefir) {
 		var property = stream.toProperty(function(){
 			return lastValue;
 		});
-		property.value = stream.emit = function(newValue) {
+		property.emit = function(newValue) {
 			if(emitter) {
-				return emitter.value(newValue);
+				return emitter.emit(newValue);
 			} else {
 				setLastValue = true;
 				lastValue = newValue;
@@ -182,7 +182,7 @@ if (Kefir) {
 
 		canReflect.assignSymbols(property,{
 			"can.setKeyValue": function(key, value){
-				this[key](value);
+				this[key === "value" ? "emit" : key](value);
 			}
 		});
 

--- a/doc/can-kefir.md
+++ b/doc/can-kefir.md
@@ -60,7 +60,7 @@ age.onValue(function(age){
   console.log(age)
 });
 
-age.value(20) //-> logs 20
+age.emit(20) //-> logs 20
 
-age.value(30) //-> logs 30
+age.emit(30) //-> logs 30
 ```

--- a/doc/can-kefir.md
+++ b/doc/can-kefir.md
@@ -48,8 +48,7 @@ document.body.appendChild(frag);
 ## emitterProperty
 
 Use [can-kefir/emitterProperty] to create an stream object that also
-has its emitter's methods.  The following creates an `age` stream that
-we can emit events on with its `value()` method:
+has an emitter-like object attached.  The following creates an `age` stream that we can emit events on with its `emitter.value()` method:
 
 ```js
 var Kefir = require("can-kefir");
@@ -60,7 +59,7 @@ age.onValue(function(age){
   console.log(age)
 });
 
-age.emit(20) //-> logs 20
+age.emitter.value(20) //-> logs 20
 
-age.emit(30) //-> logs 30
+age.emitter.value(30) //-> logs 30
 ```

--- a/doc/emitterProperty.md
+++ b/doc/emitterProperty.md
@@ -10,7 +10,7 @@ directly on it.  This is a useful writable stream.
 @type {function}
 
 Emitter property creates a Kefir [property](https://rpominov.github.io/kefir/#about-observables),
-but then adds a `value` and `error` method that calls the
+but then adds a `emit` and `error` method that calls the
 property's [emitter object](https://rpominov.github.io/kefir/#emitter-object).
 
 The end result is a single object that has methods of a stream, property and
@@ -25,7 +25,7 @@ age.onValue(function(age){
   console.log(age)
 });
 
-age.value(20) //-> logs 20
+age.emit(20) //-> logs 20
 
-age.value(30) //-> logs 30
+age.emit(30) //-> logs 30
 ```

--- a/doc/emitterProperty.md
+++ b/doc/emitterProperty.md
@@ -10,11 +10,11 @@ directly on it.  This is a useful writable stream.
 @type {function}
 
 Emitter property creates a Kefir [property](https://rpominov.github.io/kefir/#about-observables),
-but then adds a `emit` and `error` method that calls the
+but then adds `emitter.value` and `emitter.error` methods that calls the
 property's [emitter object](https://rpominov.github.io/kefir/#emitter-object).
 
 The end result is a single object that has methods of a stream, property and
-emitter.  
+an attached emitter-like object.  
 
 ```js
 var Kefir = require("can-kefir");
@@ -25,7 +25,7 @@ age.onValue(function(age){
   console.log(age)
 });
 
-age.emit(20) //-> logs 20
+age.emitter.value(20) //-> logs 20
 
-age.emit(30) //-> logs 30
+age.emitter.value(30) //-> logs 30
 ```


### PR DESCRIPTION
For #5 ... this moves the `.value` and `.error` functions to an `emitter` property on `emitterProperty` types