### PR TITLE
Add hasKey Symbol

### DIFF
--- a/can-kefir-test.js
+++ b/can-kefir-test.js
@@ -207,3 +207,10 @@ QUnit.test("getValueDependencies with multiple sources", function(assert) {
 		valueDependencies: new Set([a, b, c])
 	});
 });
+
+QUnit.test("can.hasKey Symbol", function() {
+	var foo = Kefir.emitterProperty();
+
+	equal(canReflect.hasKey(foo, 'value'), true, "It has value key");
+	equal(canReflect.hasKey(foo, 'error'), true, "It has error key");
+});

--- a/can-kefir.js
+++ b/can-kefir.js
@@ -208,6 +208,9 @@ if (Kefir) {
 		canReflect.assignSymbols(property, {
 			"can.setKeyValue": function setKeyValue(key, value) {
 				this.emitter[key](value);
+			},
+			"can.hasKey": function hasKey(key) {
+				return key in this.emitter;
 			}
 		});
 


### PR DESCRIPTION
For #21 

## The changes
`@@can.hasKey` Symbol is added to the`property` object in the `emitterProperty` object.